### PR TITLE
Remove author popover when clicking anywhere else in the article detail page.

### DIFF
--- a/js/article.js
+++ b/js/article.js
@@ -62,3 +62,14 @@ $("#goto-content").click(function () {
    $("#nav-home-tab").addClass("active");
    window.scrollTo(0, 0);
 });
+
+/* clicking anywhere in the article-detail page removes author popover */
+$('body').on('click', function (e) {
+    $('[data-toggle="popover"]').each(function () {
+        //the 'is' for buttons that trigger popups
+        //the 'has' for icons within a button that triggers a popup
+        if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+            $(this).popover('hide');
+        }
+    });
+});


### PR DESCRIPTION
This patch removes author popover from article detail page when a user clicks anywhere else in the page.
Also, it avoids opening multiple popovers.