### PR TITLE
translation of "Description" in issue.tpl

### DIFF
--- a/templates/frontend/pages/issue.tpl
+++ b/templates/frontend/pages/issue.tpl
@@ -94,7 +94,7 @@
 					{* Description *}
 					{if $issue->hasDescription()}
 						<div class="col-md-4">
-							<h3>Description</h3>
+							<h3>{translate key="common.description"}</h3>
 						</div>
 						<div class="col-md-8">
 							<div class="description">


### PR DESCRIPTION
The word "Description" in issue.tpl was hard coded. I inserted a translation tag instead.